### PR TITLE
fix : add check duplicated logic to review

### DIFF
--- a/src/exceptions/DuplicatedReview.excpetion.ts
+++ b/src/exceptions/DuplicatedReview.excpetion.ts
@@ -1,0 +1,10 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class DuplicatedReviewException extends HttpException {
+  constructor() {
+    super(
+      '이미 작성한 리뷰가 존재합니다(1개의 이벤트에는 하나의 리뷰만 작성 가능합니다).',
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+}


### PR DESCRIPTION
## ✅ PR 타입(해당하는 타입 전체 선택)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩터링

## 📝작업 내용

> soft delete 로직 추가 후, 이미 리뷰를 작성했다가 삭제한 유저가 리뷰를 생성할 수 없던 이슈를 해결함
> 관련해서 DuplicatedReviewException 를 추가함으로써 클라이언트에 적절한 메세지를 전달함

### 스크린샷
<img width="680" alt="스크린샷 2024-03-25 오후 6 40 55" src="https://github.com/moyeorak/cultureland-be/assets/91898700/ba063a78-a451-436b-98cb-3bc51fd70022">


## 연관 이슈

issue : close #119 
